### PR TITLE
Fix: naive multiplication causes float numbers and a wrong total value

### DIFF
--- a/src/utils/contractCall/index.js
+++ b/src/utils/contractCall/index.js
@@ -125,10 +125,8 @@ const bulkSendToken = async (
   const _tokenDecimals = await token.methods.decimals().call();
   const tokenDecimals = new BN(Number(_tokenDecimals))
   for (const a of _amountArr) {
-    console.log((Number(a) * 10**10).toString())
-    const _bigA = new BN((Number(a) * 10**10).toString())
-    const powTenA = _bigA.mul(ten.pow(tokenDecimals))
-    const bigA = powTenA.div(ten.pow(ten))
+    const bigA = ten.pow(tokenDecimals).muln(Number(a));
+    console.log(bigA.toString());
     amountArr.push(bigA.toString());
     total = total.add(bigA)
   }


### PR DESCRIPTION
For certain numbers, a non-big-number multiplication in the code causes the total value to be widely wrong.
This can cause, for example, approval of wrong token amounts and worse - attempting to send a bad ETH or token value.

Here is for example what happens when attempting to send 1.62 USDC:
![image](https://user-images.githubusercontent.com/16321515/90029231-4e61ff00-dcc3-11ea-937e-e49fba764751.png)


After the fix in this PR it is back to normal:
![image](https://user-images.githubusercontent.com/16321515/90029277-5c178480-dcc3-11ea-938e-8402097ddead.png)

 